### PR TITLE
Escapes

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,9 @@
-(defproject blackwaterpark/data.csv "1.0.0"
+(defproject blackwaterpark/data.csv "1.1.2"
   :description "A Clojure library for reading and writing comma separated value (csv) files (Eva fork)"
   :url "https://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "https://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.8.0"]]  
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [org.clojure/test.check "1.1.0"]]  
   :target-path "target/%s"
   :profiles {:uberjar {:aot :all}})

--- a/src/clojure/data/csv.clj
+++ b/src/clojure/data/csv.clj
@@ -47,6 +47,10 @@
                  ; Escape character followed by a quote is a quote
                  quote (do (.append sb (char quote))
                            (recur (.read reader)))
+                 
+                 ; Escape character followed by another escape character is an escape character
+                 escape (do (.append sb (char escape))
+                            (recur (.read reader)))
 
                  ; Escape character followed by anything else is the escape character
                  (do (.append sb (char escape))
@@ -121,8 +125,9 @@
 	must-quote (quote? string)]
     (when must-quote (.write writer (int quote)))
     (.write writer (if must-quote
-		     (str/escape string
-				 {quote (str escape quote)})
+		     (str/escape string 
+                   (merge {quote (str escape quote)}
+                          {escape (str escape escape)}))
 		     string))
     (when must-quote (.write writer (int quote)))))
 


### PR DESCRIPTION
This PR fixes a bug where custom escape characters were not themselves being escaped correctly when they appeared in values. This could cause problems when they were the last character in a value, e.g. `fmb\`, as they are then read as escaping the end of cell quote.